### PR TITLE
A password is not needed to fetch Github repositories

### DIFF
--- a/githubwordpress.php
+++ b/githubwordpress.php
@@ -22,9 +22,6 @@ class githubwordpress extends WP_Widget {
 		echo '<p><label for="' . $this->get_field_id("username") .'">GitHub Username:</label>';
 		echo '<input type="text" name="' . $this->get_field_name("username") . '" '; 
 		echo 'id="' . $this->get_field_id("username") . '" value="' . $instance["username"] . '" /></p>';
-		echo '<p><label for="' . $this->get_field_id("password") .'">GitHub Password:</label>';
-		echo '<input type="password" name="' . $this->get_field_name("password") . '" '; 
-		echo 'id="' . $this->get_field_id("password") . '" value="' . $instance["password"] . '" /></p>';
 		echo '</div>';
 	}
 
@@ -48,7 +45,6 @@ class githubwordpress extends WP_Widget {
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
-		//curl_setopt($ch, CURLOPT_HTTPHEADER, array($user . ":" . $password));
 		
 		// grab URL and pass it to the browser
 		$data = curl_exec($ch);
@@ -122,7 +118,6 @@ class githubwordpress extends WP_Widget {
 	function update($new_instance, $old_instance) {
 		$instance = $old_instance;		
 		$instance['username'] = strip_tags( $new_instance['username'] );
-		$instance['password'] = strip_tags( $new_instance['password'] );	
 		return $instance;
 	}		
 	


### PR DESCRIPTION
A password is not needed to fetch Github repositories. I removed the code related to it, so now it's only necessary to enter a Github username when configuring the plugin.
