### PR TITLE
Adds a missing closing div

### DIFF
--- a/githubwordpress.php
+++ b/githubwordpress.php
@@ -111,7 +111,7 @@ class githubwordpress extends WP_Widget {
 		
 		curl_close($ch);
 				
-		echo "</ul>";
+		echo "</ul></div>";
 		
 	}
 	


### PR DESCRIPTION
The widget was missing a closing DIV after the UL of projects. 
